### PR TITLE
对于原生事件做白名单

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.4.9 (waiting) 
 * `F` 修复了`onUnload`中直接赋值导致赋值失效的BUG。
 * `A` 添加了`wepy-compiler-babel`的sourceMap支持。
+* `A` 事件绑定不管是自定义事件还是原生事件都可以直接使用 `@eventName` 的方式，如果说 `eventName` 是小程序已知的事件的话就是通过 `bind` 或者 `catch` 绑定原生事件，否则的话就是走自定义事件绑定。对于小程序升级新增了一些原始事件的话，此时用户可以在 `wepy.config.js` 中增加 `nativeEvents: ['xx']` 即可。
 
 
 ## 1.4.8 (2017-03-16)

--- a/packages/wepy-cli/src/util.js
+++ b/packages/wepy-cli/src/util.js
@@ -253,6 +253,51 @@ const utils = {
             'scrolltolower',
             'scroll'
         ];
+        const knownTags = [
+            // 视图容器
+            'view',
+            'scroll-view',
+            'swiper',
+            'swiper-item',
+
+            // 基础内容
+            'icon',
+            'text',
+            'progress',
+
+            // 表单组件
+            'button',
+            'checkbox-group',
+            'checkbox',
+            'form',
+            'input',
+            'label',
+            'picker',
+            'picker-view',
+            'picker-view-column',
+            'radio-group',
+            'radio',
+            'slider',
+            'switch',
+            'textarea',
+
+            // 导航
+            'navigator',
+
+            // 媒体组件
+            'audio',
+            'image',
+            'video',
+
+            // 地图
+            'map',
+            
+            // 画布
+            'canvas',
+
+            // 客服会话
+            'contact-button'
+        ];
         const configEvents = config.nativeEvents;
         if (configEvents && Array.isArray(configEvents)) {
             // 增加可配置的 nativeEvents
@@ -261,7 +306,14 @@ const utils = {
             // 用户可以通过临时加入 nativeEvents 的方法兼容
             nativeEvents.push.apply(nativeEvents, configEvents);
         }
-        return content.replace(/<[\w-\_]*\s[^>]*>/ig, (tag) => {
+        const configTags = config.knownTags;
+        if (configTags && Array.isArray(configTags)) {
+            // 增加可配置的 knownTags
+            knownTags.push.apply(knownTags, configTags);
+        }
+        return content.replace(/<([\w-\_]*)\s[^>]*>/ig, (tag, tagName) => {
+            tagName = tagName.toLowerCase();
+            const isKnownTag = knownTags.indexOf(tagName) >= 0;
             return tag.replace(/\s+:([\w-_]*)([\.\w]*)\s*=/ig, (attr, name, type) => { // replace :param.sync => v-bind:param.sync
                 if (type === '.once' || type === '.sync') {
                 }
@@ -269,7 +321,8 @@ const utils = {
                     type = '.once';
                 return ` v-bind:${name}${type}=`;
             }).replace(/\s+\@([\w-_]*)([\.\w]*)\s*=/ig, (attr, name, type) => { // replace @change => v-on:change
-                const isNavtiveEvents = type !== '.user' && nativeEvents.indexOf(name) >= 0;
+                // 对于已知 tag 做原生事件名判断
+                const isNavtiveEvents = type !== '.user' && nativeEvents.indexOf(name) >= 0 && isKnownTag;
                 const prefix = isNavtiveEvents ? type === '.stop' ? 'catch' : 'bind' : 'v-on:';
                 return ` ${prefix}${name}=`;
             });

--- a/packages/wepy-cli/src/util.js
+++ b/packages/wepy-cli/src/util.js
@@ -35,7 +35,7 @@ colors.setTheme({
 });
 
 
-export default {
+const utils = {
 
     seqPromise(promises) {
         return new Promise((resolve, reject) => {
@@ -215,6 +215,52 @@ export default {
      * xml replace
      */
     attrReplace(content) {
+        const config = utils.getConfig();
+        const nativeEvents = [
+            // touch tap
+            'touchstart',
+            'touchmove',
+            'touchend',
+            'touchcancel',
+            'tap',
+            'longtap',
+
+            // 表单相关
+            'change',
+            'submit',
+            'reset',
+            'input',
+            'focus',
+            'blur',
+            'confirm',
+            'linechange',
+
+            // 音频 视频 等
+            'load',
+            'error',
+            'play',
+            'pause',
+            'timeupdate',
+            'ended',
+
+            // 地图
+            'markertap',
+            'controltap',
+            'regionchange',
+
+            // scroll 容器类
+            'scrolltoupper',
+            'scrolltolower',
+            'scroll'
+        ];
+        const configEvents = config.nativeEvents;
+        if (configEvents && Array.isArray(configEvents)) {
+            // 增加可配置的 nativeEvents
+            // 以防止由于小程序升级 上边的默认事件不完全导致的问题
+            // 如果说小程序升级的话 在 wepy 没升级的情况下
+            // 用户可以通过临时加入 nativeEvents 的方法兼容
+            nativeEvents.push.apply(nativeEvents, configEvents);
+        }
         return content.replace(/<[\w-\_]*\s[^>]*>/ig, (tag) => {
             return tag.replace(/\s+:([\w-_]*)([\.\w]*)\s*=/ig, (attr, name, type) => { // replace :param.sync => v-bind:param.sync
                 if (type === '.once' || type === '.sync') {
@@ -223,14 +269,8 @@ export default {
                     type = '.once';
                 return ` v-bind:${name}${type}=`;
             }).replace(/\s+\@([\w-_]*)([\.\w]*)\s*=/ig, (attr, name, type) => { // replace @change => v-on:change
-                let prefix = '';
-                if (type === '.stop') {
-                    prefix = 'catch';
-                } else if (type === '.user') {
-                    prefix = 'v-on:'
-                } else {
-                    prefix = 'bind';
-                }
+                const isNavtiveEvents = type !== '.user' && nativeEvents.indexOf(name) >= 0;
+                const prefix = isNavtiveEvents ? type === '.stop' ? 'catch' : 'bind' : 'v-on:';
                 return ` ${prefix}${name}=`;
             });
         });
@@ -421,3 +461,5 @@ export default {
         this.log(flag + ': ' + path.relative(this.currentDir, file), type);
     }
 }
+
+export default utils

--- a/packages/wepy-cli/template/src/pages/index.wpy
+++ b/packages/wepy-cli/template/src/pages/index.wpy
@@ -53,7 +53,7 @@
 
             <text class="testcounter">计数组件1: </text>
             <view class="counterview">
-                <counter1 />
+                <counter1 @index-emit="counterEmit" />
             </view>
 
             <text class="testcounter">计数组件2: </text>
@@ -195,13 +195,17 @@
                         }
                     });
                 }
+            },
+            counterEmit (...args) {
+                let $event = args[args.length - 1];
+                console.log(`${this.$name} receive ${$event.name} from ${$event.source.$name}`);
             }
         };
 
         events = {
             'index-emit': (...args) => {
                 let $event = args[args.length - 1];
-                console.log(`${this.$name} receive ${$event.name} from ${$event.source.name}`);
+                console.log(`${this.$name} receive ${$event.name} from ${$event.source.$name}`);
             }
         };
         onLoad() {


### PR DESCRIPTION
这样用户在自定义事件的时候可以直接写 `@xxx` 而不必须加上 `.user` 标识 `@xxx.user` 。

为了以防小程序升级 新增事件不在白名单内，在 wepy 没升级的前提下，开发者可以手工在 `wepy.config.js` 中加入 `nativeEvents: ['newEventName']` 配置来解决不在白名单问题。

如果说自定义事件名是和原生事件冲突，例如 `change` 的话，用户依旧可以使用 1.4.8 版本方式 `@change.user` 来绑定自定义事件。