### PR TITLE
去掉事件白名单，只保留 tag 白名单

### DIFF
--- a/packages/wepy-cli/src/util.js
+++ b/packages/wepy-cli/src/util.js
@@ -216,43 +216,6 @@ const utils = {
      */
     attrReplace(content) {
         const config = utils.getConfig();
-        const nativeEvents = [
-            // touch tap
-            'touchstart',
-            'touchmove',
-            'touchend',
-            'touchcancel',
-            'tap',
-            'longtap',
-
-            // 表单相关
-            'change',
-            'submit',
-            'reset',
-            'input',
-            'focus',
-            'blur',
-            'confirm',
-            'linechange',
-
-            // 音频 视频 等
-            'load',
-            'error',
-            'play',
-            'pause',
-            'timeupdate',
-            'ended',
-
-            // 地图
-            'markertap',
-            'controltap',
-            'regionchange',
-
-            // scroll 容器类
-            'scrolltoupper',
-            'scrolltolower',
-            'scroll'
-        ];
         const knownTags = [
             // 视图容器
             'view',
@@ -298,17 +261,12 @@ const utils = {
             // 客服会话
             'contact-button'
         ];
-        const configEvents = config.nativeEvents;
-        if (configEvents && Array.isArray(configEvents)) {
-            // 增加可配置的 nativeEvents
-            // 以防止由于小程序升级 上边的默认事件不完全导致的问题
-            // 如果说小程序升级的话 在 wepy 没升级的情况下
-            // 用户可以通过临时加入 nativeEvents 的方法兼容
-            nativeEvents.push.apply(nativeEvents, configEvents);
-        }
         const configTags = config.knownTags;
         if (configTags && Array.isArray(configTags)) {
             // 增加可配置的 knownTags
+            // 以防止由于小程序升级 上边的默认tag不完全导致的问题
+            // 如果说小程序升级的话 在 wepy 没升级的情况下
+            // 用户可以通过临时加入 knownTags 的方法兼容
             knownTags.push.apply(knownTags, configTags);
         }
         return content.replace(/<([\w-\_]*)\s[^>]*>/ig, (tag, tagName) => {
@@ -322,7 +280,7 @@ const utils = {
                 return ` v-bind:${name}${type}=`;
             }).replace(/\s+\@([\w-_]*)([\.\w]*)\s*=/ig, (attr, name, type) => { // replace @change => v-on:change
                 // 对于已知 tag 做原生事件名判断
-                const isNavtiveEvents = type !== '.user' && nativeEvents.indexOf(name) >= 0 && isKnownTag;
+                const isNavtiveEvents = type !== '.user' && isKnownTag;
                 const prefix = isNavtiveEvents ? type === '.stop' ? 'catch' : 'bind' : 'v-on:';
                 return ` ${prefix}${name}=`;
             });


### PR DESCRIPTION
后来思考了下，如果加了 tag 白名单做法，貌似再加上事件白名单就有点多余了；

现在就直接简化为 原生 tag 绑定就是 bind(catch) ，自定义组件就是 v-on: 。

不知以 @Gcaufy  判断来看是否还需要事件白名单。o(╯□╰)o