### PR TITLE
修复 wepy-plugin-replace 的配置项为一个数组的时候无效的问题

### DIFF
--- a/packages/wepy-plugin-replace/src/index.js
+++ b/packages/wepy-plugin-replace/src/index.js
@@ -9,6 +9,11 @@ export default class {
             }
         };
 
+        if (Array.isArray(c)) {
+            this.setting = c.map(s => Object.assign({}, def, s));
+            return;
+        }
+
         this.setting = Object.assign({}, def, c);
     }
     apply (op) {


### PR DESCRIPTION
wepy-plugin-replace 的配置项可以是一个数组，这时候构造函数里面 this.setting 这个属性应该被设置成一个数组，而不是一个对象。