### PR TITLE
New命令支持使用当前目录 & 修复package.json会被copy覆盖的问题

### DIFF
--- a/packages/wepy-cli/src/wepy.js
+++ b/packages/wepy-cli/src/wepy.js
@@ -105,7 +105,7 @@ let generateProject = (name, config) => {
     util.writeFile(packagePath, JSON.stringify(pkg));
     util.log('配置: ' + 'package.json', '写入');
 
-    let files = util.getFiles(template);
+    let files = util.getFiles(template).filter(file => file !== 'package.json');
 
     const copyFn = function (sourcePath) {
         return function (file) {

--- a/packages/wepy-cli/src/wepy.js
+++ b/packages/wepy-cli/src/wepy.js
@@ -23,7 +23,7 @@ let generateProject = (name, config) => {
     let inPlace = !name || name === '.';
 
     if (inPlace) {
-        name = process.cwd().split('/').pop();
+        name = process.cwd().split(path.sep).pop();
         util.log('使用当前目录：' + name);
     } else {
         util.log('目录：' + name, '创建');

--- a/packages/wepy-cli/src/wepy.js
+++ b/packages/wepy-cli/src/wepy.js
@@ -20,14 +20,21 @@ let displayVersion = () => {
 
 let generateProject = (name, config) => {
 
-    util.log('目录：' + name, '创建');
+    let inPlace = !name || name === '.';
 
-    if (util.mkdir(name) !== true) {
-        util.error('创建目录失败。');
-        return;
+    if (inPlace) {
+        util.log('使用当前目录');
+    } else {
+        util.log('目录：' + name, '创建');
+
+        if (util.mkdir(name) !== true) {
+            util.error('创建目录失败。');
+            return;
+        }
+    
+        process.chdir(name);
     }
 
-    process.chdir(name);
     util.currentDir = process.cwd();
 
     let packagePath = path.join(util.currentDir, 'package.json');

--- a/packages/wepy-cli/src/wepy.js
+++ b/packages/wepy-cli/src/wepy.js
@@ -23,7 +23,8 @@ let generateProject = (name, config) => {
     let inPlace = !name || name === '.';
 
     if (inPlace) {
-        util.log('使用当前目录');
+        name = process.cwd().split('/').pop();
+        util.log('使用当前目录：' + name);
     } else {
         util.log('目录：' + name, '创建');
 
@@ -31,7 +32,7 @@ let generateProject = (name, config) => {
             util.error('创建目录失败。');
             return;
         }
-    
+
         process.chdir(name);
     }
 


### PR DESCRIPTION
* Leave empty or `.` when using `new` command will use current directory automatically.