### PR TITLE
修复调用组件getCurrentPages出错

### DIFF
--- a/packages/wepy/src/component.js
+++ b/packages/wepy/src/component.js
@@ -250,7 +250,7 @@ export default class {
     }
 
     getCurrentPages () {
-        return this.$wxpage.getCurrentPages();
+        return getCurrentPages();
     }
 
     /**


### PR DESCRIPTION
代码中调用的是this.$wxpage.getCurrentPages，而getCurrentPages是全局方法