### PR TITLE
修改正则表达式

### DIFF
--- a/packages/wepy-plugin-replace/src/index.js
+++ b/packages/wepy-plugin-replace/src/index.js
@@ -4,7 +4,7 @@ export default class {
 
     constructor(c = {}) {
         const def = {
-            filter: new RegExp('\w$'),
+            filter: /\w$/,
             config: {
             }
         };
@@ -36,7 +36,7 @@ export default class {
         }
 
         settings.forEach((setting) => {
-            if (setting.filter.test(op.file)) {
+            if (op.code !== null && setting.filter.test(op.file)) {
                 op.output && op.output({
                     action: '变更',
                     file: op.file


### PR DESCRIPTION
原来直接 new RegExp('\w$') 会解析成  /w$/
svg等文件是取不到op.code的会直接为null 所以后面需要判断 op.code !== null

不修改正则，所有文件都匹配不到