### PR TITLE
支持 uploadTask / downloadTask

### DIFF
--- a/packages/wepy/src/app.js
+++ b/packages/wepy/src/app.js
@@ -157,8 +157,13 @@ export default class {
                                     });
                                     if (self.$addons.requestfix && key === 'request') {
                                         RequestMQ.request(obj);
-                                    } else
-                                        wx[key](obj);
+                                    } else {
+                                      const task =  wx[key](obj);
+                                        if (key === 'uploadFile' || key === 'downloadFile') {
+                                            task.onProgressUpdate && obj.onProgressUpdate && task.onProgressUpdate(obj.onProgressUpdate);
+                                            task.abort && obj.abort && task.abort();
+                                        }
+                                    }
                                 });
                             } else {
                                 let bak = {};
@@ -173,8 +178,13 @@ export default class {
                                 });
                                 if (self.$addons.requestfix && key === 'request') {
                                     RequestMQ.request(obj);
-                                } else
-                                    wx[key](obj);
+                                } else{
+                                    const task =  wx[key](obj);
+                                    if (key === 'uploadFile' || key === 'downloadFile') {
+                                        task.onProgressUpdate && obj.onProgressUpdate && task.onProgressUpdate(obj.onProgressUpdate);
+                                        task.abort && obj.abort && task.abort();
+                                    }
+                                }
                             }
                         };
                     }

--- a/packages/wepy/src/app.js
+++ b/packages/wepy/src/app.js
@@ -34,7 +34,6 @@ let RequestMQ = {
         }
     },
     request (obj) {
-        let me = this;
 
         obj = obj || {};
         obj = (typeof(obj) === 'string') ? {url: obj} : obj;
@@ -83,7 +82,7 @@ export default class {
     }
 
     $initAPI (wepy, noPromiseAPI) {
-        var self = this;
+        const self = this;
         let noPromiseMethods = {
             stopRecord: true,
             pauseVoice: true,
@@ -151,7 +150,7 @@ export default class {
                                                 res = self.$interceptors[key][k].call(self, res);
                                             }
                                             if (k === 'success')
-                                                resolve(res)
+                                                resolve(res);
                                             else if (k === 'fail')
                                                 reject(res);
                                         };
@@ -164,16 +163,16 @@ export default class {
                                 });
                                 if (key === 'uploadFile' || key === 'downloadFile') {
                                     p.progress = (cb) => {
-                                        task.onProgressUpdate(cb)
-                                        return p
-                                    }
+                                        task.onProgressUpdate(cb);
+                                        return p;
+                                    };
                                     p.abort = (cb) => {
-                                        cb && cb()
-                                        task.abort()
-                                        return p
+                                        cb && cb();
+                                        task.abort();
+                                        return p;
                                     }
                                 }
-                                return p
+                                return p;
                             } else {
                                 let bak = {};
                                 ['fail', 'success', 'complete'].forEach((k) => {

--- a/packages/wepy/test/app.js
+++ b/packages/wepy/test/app.js
@@ -243,8 +243,66 @@ describe('app.js', () => {
 
     });
 
+    it('api (upload/download)File support (upload/download)Task Object', () => {
+
+        const onProgressUpdate = (res) => {
+            assert.strictEqual(res.progress, 50, '(upload/download)Task success');
+            assert.strictEqual(res.totalBytesSent, 512, '(upload/download)Task success');
+            assert.strictEqual(res.totalBytesExpectedToSend, 1024, '(upload/download)Task success');
+        }
+
+        wepy.uploadFile({
+            url: 'https://example.weixin.qq.com/upload', //仅为示例，非真实的接口地址
+            filePath: 'tempFilePath',
+            name: 'file',
+            onProgressUpdate,
+            abort: true
+        })
+
+        wepy.downloadFile({
+            url: 'https://example.weixin.qq.com/upload', //仅为示例，非真实的接口地址
+            header: 'tempFilePath',
+            onProgressUpdate,
+            abort: true
+        })
+
+    });
+
+    it('api use promisify (upload/download)File support (upload/download)Task Object', () => {
+
+        app.use('promisify');
+
+        let actualRes = {}
+        const onProgressUpdate = (res) => {
+            actualRes = res
+        }
+
+        wepy.uploadFile({
+            url: 'https://example.weixin.qq.com/upload', //仅为示例，非真实的接口地址
+            filePath: 'tempFilePath',
+            name: 'file',
+            onProgressUpdate,
+            abort: true
+        }).then(function (res) {
+            assert.strictEqual(res.success, 'success', 'upload success');
+        });
+
+        wepy.downloadFile({
+            url: 'https://example.weixin.qq.com/upload', //仅为示例，非真实的接口地址
+            filePath: 'tempFilePath',
+            name: 'file',
+            onProgressUpdate,
+            abort: true
+        }).then(function (res) {
+            assert.strictEqual(res.success, 'success', 'download success');
+        });
+
+        assert.strictEqual(actualRes.progress, 50, '(upload/download)Task success');
+        assert.strictEqual(actualRes.totalBytesSent, 512, '(upload/download)Task success');
+        assert.strictEqual(actualRes.totalBytesExpectedToSend, 1024, '(upload/download)Task success');
 
 
+    });
 
 
 });

--- a/packages/wepy/test/wxfake.js
+++ b/packages/wepy/test/wxfake.js
@@ -48,7 +48,43 @@ module.exports = {
             },
             navigateBack: function () {
                 //console.log('navigateBack');
-            }
+            },
+            uploadFile: function (p) {
+                p.success({
+                    success: 'success'
+                });
+                p.complete({
+                    complete: 'complete'
+                });
+
+                const uploadTask = {
+                    onProgressUpdate: (callback) => callback({
+                        progress: 50,
+                        totalBytesSent: 512,
+                        totalBytesExpectedToSend: 1024
+                    }),
+                    abort: () => console.log('upload abort')
+                }
+                return uploadTask
+            },
+            downloadFile: function (p) {
+                p.success({
+                    success: 'success'
+                });
+                p.complete({
+                    complete: 'complete'
+                });
+
+                const downloadTask = {
+                    onProgressUpdate: (callback) => callback({
+                        progress: 50,
+                        totalBytesSent: 512,
+                        totalBytesExpectedToSend: 1024
+                    }),
+                    abort: () => console.log('download abort')
+                }
+                return downloadTask
+            },
         };
 
         global.getApp = function () { return {app:'app'}; };


### PR DESCRIPTION
支持 `uploadTask` / `downloadTask`，可监听上传 / 下载进度变化事件，以及取消上传 / 下载任务。

使用方式
```
wepy.uploadFile({
    url: 'https://example.weixin.qq.com/upload', //仅为示例，非真实的接口地址
    filePath: 'tempFilePath',
    name: 'file',
})
.progress(res => {
    console.log('上传进度', res.progress)
    console.log('已经上传的数据长度', res.totalBytesSent)
    console.log('预期需要上传的数据总长度', res.totalBytesExpectedToSend)
})
.abort(() => {
    // todo sth 处理中断任务
    console.info('uploadFile abort custom')
})
.then((res) => {
    // todo sth
});
```

```
const resp = await wepy.uploadFile({
    url: 'https://example.weixin.qq.com/upload', //仅为示例，非真实的接口地址
    filePath: 'tempFilePath',
    name: 'file',
})
.progress(res => {
    console.log('上传进度', res.progress)
    console.log('已经上传的数据长度', res.totalBytesSent)
    console.log('预期需要上传的数据总长度', res.totalBytesExpectedToSend)
})
.abort(() => {
    // todo sth 处理中断任务
    console.info('uploadFile abort custom')
})
.catch(errorHandler)
```
